### PR TITLE
simplified the Device class

### DIFF
--- a/device.py
+++ b/device.py
@@ -1,8 +1,38 @@
 from clip import Clip
 
 
-class Device():
+class DeviceOutput:
+    def __init__(self, method, name=None):
+        self.method = method
+        self.name = name or method.__name__
+        self.__doc__ = method.__doc__
 
+    def get_mapping(self, inst):
+        return inst.mapping
+
+    def __get__(self, inst, cls=None):
+        mapping = self.get_mapping(inst)
+        return mapping.setdefault(self.name, self.method(inst))
+
+    def __set__(self, inst, value):
+        mapping = self.get_mapping(inst)
+        mapping[self.name] = value
+        # inst.update_lookup()
+
+    def __delete__(self, inst):
+        mapping = self.get_mapping(inst)
+        del mapping[self.name]
+        # inst.update_lookup()
+
+
+class DeviceInput(DeviceOutput):
+    # def get_mapping(self, inst):
+    #    return inst.mapping
+
+    pass
+
+
+class Device:
     def __init__(self, mapping=None):
         if mapping is None:
             self.updateMapping({})
@@ -44,182 +74,76 @@ class Device():
 
     @property
     def name(self):
-        if 'name' in self.mapping:
-            return self.mapping['name']
-        else:
-            return ""
+        return self.mapping.get('name', '')
 
     @name.setter
     def name(self, name):
         self.mapping['name'] = name
 
-    @property
+    @DeviceInput
     def ctrls(self):
-        if 'ctrls' not in self.mapping:
-            self.mapping['ctrls'] = []
-        return self.mapping['ctrls']
+        return []
 
-    @property
+    @DeviceInput
     def start_stop(self):
-        if 'start_stop' not in self.mapping:
-            self.mapping['start_stop'] = []
-        return self.mapping['start_stop']
+        return []
 
-    @property
+    @DeviceInput
     def init_command(self):
-        if 'init_command' not in self.mapping:
-            self.mapping['init_command'] = []
-        return self.mapping['init_command']
+        return []
 
-    @property
+    @DeviceInput
     def block_buttons(self):
-        if 'block_buttons' not in self.mapping:
-            self.mapping['block_buttons'] = []
-        return self.mapping['block_buttons']
+        return []
 
-    @property
+    @DeviceInput
     def master_volume_ctrl(self):
-        if 'master_volume_ctrl' in self.mapping:
-            return self.mapping['master_volume_ctrl']
-        else:
-            return False
+        return False
 
-    @master_volume_ctrl.setter
-    def master_volume_ctrl(self, ctrl_key):
-        self.mapping['master_volume_ctrl'] = ctrl_key
-
-    @property
+    @DeviceInput
     def play_btn(self):
-        if 'play_btn' in self.mapping:
-            return self.mapping['play_btn']
-        else:
-            return False
+        return False
 
-    @play_btn.setter
-    def play_btn(self, btn):
-        self.mapping['play_btn'] = btn
-
-    @property
+    @DeviceInput
     def pause_btn(self):
-        if 'pause_btn' in self.mapping:
-            return self.mapping['pause_btn']
-        else:
-            return False
+        return False
 
-    @pause_btn.setter
-    def pause_btn(self, btn):
-        self.mapping['pause_btn'] = btn
-
-    @property
+    @DeviceInput
     def rewind_btn(self):
-        if 'rewind_btn' in self.mapping:
-            return self.mapping['rewind_btn']
-        else:
-            return False
+        return False
 
-    @rewind_btn.setter
-    def rewind_btn(self, btn):
-        self.mapping['rewind_btn'] = btn
-
-    @property
+    @DeviceInput
     def goto_btn(self):
-        if 'goto_btn' in self.mapping:
-            return self.mapping['goto_btn']
-        else:
-            return False
+        return False
 
-    @goto_btn.setter
-    def goto_btn(self, btn):
-        self.mapping['goto_btn'] = btn
-
-    @property
+    @DeviceInput
     def record_btn(self):
-        if 'record_btn' in self.mapping:
-            return self.mapping['record_btn']
-        else:
-            return False
+        return False
 
-    @record_btn.setter
-    def record_btn(self, btn):
-        self.mapping['record_btn'] = btn
-
-    @master_volume_ctrl.setter
-    def master_volume_ctrl(self, ctrl_key):
-        self.mapping['master_volume_ctrl'] = ctrl_key
-
-    @property
+    @DeviceOutput
     def black_vel(self):
-        if 'black_vel' in self.mapping:
-            return self.mapping['black_vel']
-        else:
-            return 0
+        return 0
 
-    @property
+    @DeviceOutput
     def green_vel(self):
-        if 'green_vel' in self.mapping:
-            return self.mapping['green_vel']
-        else:
-            return 0
+        return 0
 
-    @property
+    @DeviceOutput
     def blink_green_vel(self):
-        if 'blink_green_vel' in self.mapping:
-            return self.mapping['blink_green_vel']
-        else:
-            return 0
+        return 0
 
-    @property
+    @DeviceOutput
     def red_vel(self):
-        if 'red_vel' in self.mapping:
-            return self.mapping['red_vel']
-        else:
-            return 0
+        return 0
 
-    @property
+    @DeviceOutput
     def blink_red_vel(self):
-        if 'blink_red_vel' in self.mapping:
-            return self.mapping['blink_red_vel']
-        else:
-            return 0
+        return 0
 
-    @property
+    @DeviceOutput
     def amber_vel(self):
-        if 'amber_vel' in self.mapping:
-            return self.mapping['amber_vel']
-        else:
-            return 0
+        return 0
 
-    @property
+    @DeviceOutput
     def blink_amber_vel(self):
-        if 'blink_amber_vel' in self.mapping:
-            return self.mapping['blink_amber_vel']
-        else:
-            return 0
-
-    @black_vel.setter
-    def black_vel(self, vel):
-        self.mapping['black_vel'] = vel
-
-    @green_vel.setter
-    def green_vel(self, vel):
-        self.mapping['green_vel'] = vel
-
-    @blink_green_vel.setter
-    def blink_green_vel(self, vel):
-        self.mapping['blink_green_vel'] = vel
-
-    @red_vel.setter
-    def red_vel(self, vel):
-        self.mapping['red_vel'] = vel
-
-    @blink_red_vel.setter
-    def blink_red_vel(self, vel):
-        self.mapping['blink_red_vel'] = vel
-
-    @amber_vel.setter
-    def amber_vel(self, vel):
-        self.mapping['amber_vel'] = vel
-
-    @blink_amber_vel.setter
-    def blink_amber_vel(self, vel):
-        self.mapping['blink_amber_vel'] = vel
+        return 0


### PR DESCRIPTION
This commit rewrites the Device class **without actually changing**
- anything about what it does _(see code example for a small exception)_, or 
- the internal representation of its data _(its still the same dict `mapping` containing all the data that needs to be saved/loaded for the midi binding including the devices name)_

From my understanding, the purpose of the `Device` class is to have a clear explicitly defined way of accessing (and potentially documenting) all the fields in the devices - this PR aims to improve it.
**So what does it change?**

1. the code is much shorter (easier to read and change)
2. it distinguishes (only on a syntactical level) the Input-related mapping from the output related mapping.

**How does it do it?**

1. The old code contained a lot of redundancy, most of which it got rid of.
All data was accessed with properties allowing to read and write it.
properties in python work, by implementing the [descriptor protocol](https://docs.python.org/3.5/howto/descriptor.html). The new code shifts all the redundancy inside the descriptor methods of a new custom decorator called `DeviceOutput`.
2. another custom decorator called `DeviceInput` inherits everything from  `DeviceOutput` but changes nothing - for now it is just a mere name to syntactically be able to distinguish Outputs from Inputs.

**Detailed explanation regarding 1. by code example**
Lets view the changes by the example case of the data field `master_volume_ctrl`. The old code looks like this:
```python
    @property
    def master_volume_ctrl(self):
        if 'master_volume_ctrl' in self.mapping:
            return self.mapping['master_volume_ctrl']
        else:
            return False

    @master_volume_ctrl.setter
    def master_volume_ctrl(self, ctrl_key):
        self.mapping['master_volume_ctrl'] = ctrl_key
```
The string `master_volume_ctrl` appeares 6 times: 3 times in the getter and setter each.
In a first step, the (build-in) dictionary method [setdefault](https://docs.python.org/3.5/library/stdtypes.html#dict.setdefault) can abbreviate the code without changing its behavior like this:
```python
    @property
    def master_volume_ctrl(self):
        return self.mapping.setdefault('master_volume_ctrl', False)

    @master_volume_ctrl.setter
    def master_volume_ctrl(self, ctrl_key):
        self.mapping['master_volume_ctrl'] = ctrl_key
```
_Note:_ Actually the behavior is slightly changed here: in case the mapping has no value, the default value is written to the mapping (not the case before). I can imagine this might be desirable if we want to be able to distinguish different serialized device versions better.
If you find it is not desirable to do so, [dict.get](https://docs.python.org/3.5/library/stdtypes.html#dict.get) would do the exact same job, as the old code.

Finally the custom decorator encapsulates the getter and setter logic:
```python
    @DeviceInput
    def master_volume_ctrl(self):
        return False
```
- the constant return value of the virgin method (before it is passed to the `DeviceInput` decorator) i used by the  `DeviceInput` decorator as the default value, if none is/was set.
- the method name which is needed for the key in mapping is retrieved by calling `method.__name__` in the decorator.

I hope all this is understandable and easy to digest :