### PR TITLE
Force loading soundfile as two-dimensional array

### DIFF
--- a/clip.py
+++ b/clip.py
@@ -322,7 +322,7 @@ def load_song_from_file(file):
                 wav_res = zip.open(member)
                 buffer.write(wav_res.read())
                 buffer.seek(0)
-                data, samplerate = sf.read(buffer, dtype=np.float32)
+                data, samplerate = sf.read(buffer, dtype=np.float32, always_2d=True)
                 res.data[member] = data
                 res.samplerate[member] = samplerate
 


### PR DESCRIPTION
It seems that default value of soundfile read() change :
bastibe/SoundFile#133
`always_2d` parameter switch from `True` to `False`. So to keep old behaviour we need to set `always_2d=True`