### PR TITLE
AkaiApcKey25 & Docs

### DIFF
--- a/AkaiApcKey25_config
+++ b/AkaiApcKey25_config
@@ -1,0 +1,1 @@
+In attachment, a few words on this controller configuration (in English and Italian both).


### PR DESCRIPTION
Here in attachment the controller script and docs about it.

My suggestion, if possible, is to create in SB' root directory, a subdir named e.g. "controllers" in which to put all sbm files and docs

[AKAI_APC_Key25.sbm.zip](https://github.com/Vampouille/superboucle/files/4444356/AKAI_APC_Key25.sbm.zip)

[AKAI_APC_Key25_SB-en.pdf](https://github.com/Vampouille/superboucle/files/4444366/AKAI_APC_Key25_SB-en.pdf)
[AKAI_APC_Key25_SB-it.pdf](https://github.com/Vampouille/superboucle/files/4444367/AKAI_APC_Key25_SB-it.pdf)
